### PR TITLE
Put no-byte-compile back for security. 

### DIFF
--- a/monokai-alt-theme.el
+++ b/monokai-alt-theme.el
@@ -320,6 +320,7 @@
 
 ;; Local Variables:
 ;; fill-column: 120
+;; no-byte-compile: t
 ;; End:
 
 ;;; monokai-alt-theme.el ends here


### PR DESCRIPTION
Users can override this after they review it and think it is safe.